### PR TITLE
Add automatic build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,30 @@
+name: "Pull Request Docs Check"
+on: 
+- pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v3
+    - name: Install prerequisites
+      run: | 
+        sudo apt-get --allow-releaseinfo-change update -y && sudo apt-get install -y tox
+    - name: Building RC2
+      run: |
+        cd doc/ref_cert/RC2
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RC2 ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RC2 was successful! "
+    - name: Store html build result
+      uses: actions/upload-artifact@v3
+      with:
+          name: rc2-html
+          path: |
+           doc/ref_cert/RC2/build
+
+
+        

--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -204,7 +204,7 @@ Network Testing
 The regexes load.balancer, LoadBalancer and
 Network.should.set.TCP.CLOSE_WAIT.timeout are currently skipped because
 they haven’t been covered successfully neither by
-`sig-release-1.25-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml>`__
+`sig-release-1.25-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml>`__
 nor by `Anuket RC2
 verification <https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.25-daily/11/>`__
 

--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -285,7 +285,7 @@ Storage Testing
 
 It should be noted that all in-tree driver testing, [Driver:+], is
 skipped. Conforming to `the upstream
-gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml>`__,
+gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml>`__,
 all PersistentVolumes NFS testing is also skipped. The following
 exclusions are about `the deprecated in-tree GitRepo volume
 type <https://github.com/kubernetes-sigs/kind/issues/2356>`__:

--- a/doc/ref_cert/RC2/chapters/chapter03.rst
+++ b/doc/ref_cert/RC2/chapters/chapter03.rst
@@ -12,7 +12,7 @@ description file will be proposed in a shared tree.
 `Xtesting CI <https://galaxy.ansible.com/collivier/xtesting>`__ only
 requires internet access, GNU/Linux as Operating System and asks for a
 few dependencies as described in `Deploy your own Xtesting CI/CD
-toolchains <https://github.com/collivier/ansible-role-xtesting`__:
+toolchains <https://github.com/collivier/ansible-role-xtesting>`__:
 
 -  python-virtualenv
 -  git

--- a/doc/ref_cert/RC2/chapters/chapter03.rst
+++ b/doc/ref_cert/RC2/chapters/chapter03.rst
@@ -12,7 +12,7 @@ description file will be proposed in a shared tree.
 `Xtesting CI <https://galaxy.ansible.com/collivier/xtesting>`__ only
 requires internet access, GNU/Linux as Operating System and asks for a
 few dependencies as described in `Deploy your own Xtesting CI/CD
-toolchains <https://github.com/collivier/ansible-role-xtesting#readme>`__:
+toolchains <https://github.com/collivier/ansible-role-xtesting`__:
 
 -  python-virtualenv
 -  git


### PR DESCRIPTION
@collivier to fix the broken links I've changed https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml to https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml in a couple of places, I hope it is ok. 