### PR TITLE
Update Kubernetes release to v1.29

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -203,10 +203,10 @@ Network Testing
 
 The regexes load.balancer, LoadBalancer and
 Network.should.set.TCP.CLOSE_WAIT.timeout are currently skipped because
-they haven’t been covered successfully neither by
-`sig-release-1.25-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml>`__
+they haven't been covered successfully neither by
+`sig-release-1.29-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml>`__
 nor by `Anuket RC2
-verification <https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.25-daily/11/>`__
+verification <http://104.154.71.112:8080/job/functest-kubernetes-v1.29-daily>`__
 
 Please note that a couple of tests must be skipped by name below as they
 are no appropriate labels.
@@ -285,7 +285,7 @@ Storage Testing
 
 It should be noted that all in-tree driver testing, [Driver:+], is
 skipped. Conforming to `the upstream
-gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml>`__,
+gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml>`__,
 all PersistentVolumes NFS testing is also skipped. The following
 exclusions are about `the deprecated in-tree GitRepo volume
 type <https://github.com/kubernetes-sigs/kind/issues/2356>`__:
@@ -328,9 +328,9 @@ Kubernetes API benchmarking
 that performs Kubernetes API benchmarking.
 
 `Functest Kubernetes
-Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.25>`__
+Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.29>`__
 proposed a Rally-based test case,
-`xrally_kubernetes_full <https://artifacts.opnfv.org/functest-kubernetes/H9DF0X9T6DHH/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.25-xrally_kubernetes_full-run-2/xrally_kubernetes_full/xrally_kubernetes_full.html>`__,
+`xrally_kubernetes_full <https://artifacts.opnfv.org/functest-kubernetes/671YK0WH9PRK/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.29-xrally_kubernetes_full-run-9/xrally_kubernetes_full/xrally_kubernetes_full.html>`__,
 which iterates 10 times the mainline
 `xrally-kubernetes <https://github.com/xrally/xrally-kubernetes>`__
 scenarios.
@@ -338,10 +338,10 @@ scenarios.
 At the time of writing, no KPI is defined in :doc:`ref_arch_kubernetes:index`
 which would have asked for an update of the default SLA (maximum failure
 rate of 0%) proposed in `Functest Kubernetes
-Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.25>`__
+Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.29>`__
 
 `Functest
-xrally_kubernetes_full <hhttps://artifacts.opnfv.org/functest-kubernetes/H9DF0X9T6DHH/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.25-xrally_kubernetes_full-run-2/xrally_kubernetes_full/xrally_kubernetes_full.html>`__:
+xrally_kubernetes_full <https://artifacts.opnfv.org/functest-kubernetes/671YK0WH9PRK/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.29-xrally_kubernetes_full-run-9/xrally_kubernetes_full/xrally_kubernetes_full.html>`__:
 
 .. list-table:: Kubernetes API benchmarking
    :widths: 80 20
@@ -395,7 +395,7 @@ xrally_kubernetes_full <hhttps://artifacts.opnfv.org/functest-kubernetes/H9DF0X9
      - 10
 
 The following software versions are considered to benchmark Kubernetes
-v1.25 (latest stable release) selected by Anuket:
+v1.29 (latest stable release) selected by Anuket:
 
 .. list-table:: Software versions
    :widths: 50 50
@@ -404,7 +404,7 @@ v1.25 (latest stable release) selected by Anuket:
    * - Software
      - Version
    * - Functest
-     - v1.25
+     - v1.29
    * - xrally-kubernetes
      - 1.1.1.dev12
 
@@ -437,14 +437,14 @@ modes) and `Netperf <https://github.com/HewlettPackard/netperf/>`__.
 At the time of writing, no KPI is defined in Anuket chapters which would
 have asked for an update of the default SLA proposed in `Functest
 Kubernetes
-Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking?h=stable/v1.25>`__.
+Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking?h=stable/v1.29>`__.
 
 Security testing
 ~~~~~~~~~~~~~~~~
 
 There are a couple of opensource tools that help securing the Kubernetes
 stack. Amongst them, `Functest Kubernetes
-Security <https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.25>`__
+Security <https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.29>`__
 offers two test cases based on
 `kube-hunter <https://github.com/aquasecurity/kube-hunter>`__ and
 `kube-bench <https://github.com/aquasecurity/kube-bench>`__.
@@ -488,10 +488,10 @@ rules are defined as mandatory (e.g., sec.std.001: The Cloud Operator
 it would have required an update of the default kube-bench behavior (all
 failures and warnings are only printed) as integrated in `Functest
 Kubernetes
-Security <https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.25>`__.
+Security <https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.29>`__.
 
 The following software versions are considered to verify Kubernetes
-v1.25 (latest stable release) selected by Anuket:
+v1.29 (latest stable release) selected by Anuket:
 
 .. list-table:: Software versions
    :widths: 50 50
@@ -500,7 +500,7 @@ v1.25 (latest stable release) selected by Anuket:
    * - Software
      - Version
    * - Functest
-     - v1.25
+     - v1.29
    * - kube-hunter
      - 0.6.8
    * - kube-bench
@@ -520,7 +520,7 @@ upstream tests (see
 `clearwater-live-test <https://github.com/Metaswitch/clearwater-live-test>`__).
 
 The following software versions are considered to verify Kubernetes
-v1.25 (latest stable release) selected by Anuket:
+v1.29 (latest stable release) selected by Anuket:
 
 .. list-table:: Software versions
    :widths: 50 50
@@ -529,7 +529,7 @@ v1.25 (latest stable release) selected by Anuket:
    * - Software
      - Version
    * - Functest
-     - v1.25
+     - v1.29
    * - clearwater
      - release-130
    * - Helm
@@ -548,91 +548,91 @@ The following test case must pass as they are for Reference Conformance:
      - Test suite
      - Criteria
      - Requirements
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - xrally_kubernetes
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - k8s_conformance
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - k8s_conformance_serial
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_api_machinery
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_api_machinery_serial
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_apps
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_apps_serial
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_auth
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_cluster_lifecycle
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_instrumentation
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_network
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_node
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_scheduling_serial
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_storage
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-smoke:v1.25
+   * - opnfv/functest-kubernetes-smoke:v1.29
      - sig_storage_serial
      - PASS
      - Kubernetes API testing
-   * - opnfv/functest-kubernetes-security:v1.25
+   * - opnfv/functest-kubernetes-security:v1.29
      - kube_hunter
      - PASS
      - Security testing
-   * - opnfv/functest-kubernetes-security:v1.25
+   * - opnfv/functest-kubernetes-security:v1.29
      - kube_bench_master
      - PASS
      - Security testing
-   * - opnfv/functest-kubernetes-security:v1.25
+   * - opnfv/functest-kubernetes-security:v1.29
      - kube_bench_node
      - PASS
      - Security testing
-   * - opnfv/functest-kubernetes-benchmarking:v1.25
+   * - opnfv/functest-kubernetes-benchmarking:v1.29
      - xrally_kubernetes_full
      - PASS
      - Kubernetes API benchmarking
-   * - opnfv/functest-kubernetes-benchmarking:v1.25
+   * - opnfv/functest-kubernetes-benchmarking:v1.29
      - netperf
      - PASS
      - Dataplane benchmarking
-   * - opnfv/functest-kubernetes-cnf:v1.25
+   * - opnfv/functest-kubernetes-cnf:v1.29
      - k8s_vims
      - PASS
      - Opensource CNF onboarding and testing
-   * - opnfv/functest-kubernetes-cnf:v1.25
+   * - opnfv/functest-kubernetes-cnf:v1.29
      - helm_vims
      - PASS
      - Opensource CNF onboarding and testing

--- a/doc/ref_cert/RC2/chapters/chapter03.rst
+++ b/doc/ref_cert/RC2/chapters/chapter03.rst
@@ -36,7 +36,7 @@ To deploy your own CI toolchain running Anuket Compliance:
    ansible-galaxy install collivier.xtesting
    ansible-galaxy collection install ansible.posix community.general community.grafana kubernetes.core community.docker community.postgresql
    git clone https://gerrit.opnfv.org/gerrit/functest-kubernetes functest-kubernetes-src
-   (cd functest-kubernetes-src && git checkout -b stable/v1.25 origin/stable/v1.25)
+   (cd functest-kubernetes-src && git checkout -b stable/v1.29 origin/stable/v1.29)
    ansible-playbook functest-kubernetes-src/ansible/site.cntt.yml
 
 Configure Kubernetes API testing
@@ -51,13 +51,13 @@ cookbook:
 Run Kubernetes conformance suite
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open http://127.0.0.1:8080/job/functest-kubernetes-v1.25-daily/ in a web
+Open http://127.0.0.1:8080/job/functest-kubernetes-v1.29-daily/ in a web
 browser, login as admin/admin and click on “Build with Parameters” (keep
 the default values).
 
 If the System under test (SUT) is Anuket compliant, a link to the full
 archive containing all test results and artifacts will be printed in
-functest-kubernetes-v1.25-zip’s console. Be free to download it and then
+functest-kubernetes-v1.29-zip’s console. Be free to download it and then
 to send it to any reviewer committee.
 
 To clean your working dir:

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -12,7 +12,6 @@ extensions = [
 html_theme = "piccolo_theme"
 linkcheck_ignore = [
     'http://127.0.0.1',
-    'https://build.opnfv.org/',
     'https://github.com/cnti-testcatalog/testsuite/blob/main/RATIONALE.md#'
 ]
 intersphinx_mapping = {


### PR DESCRIPTION
RA2 made the choice to support v1.29.